### PR TITLE
Disable service acccount access from inside kubernetes pods

### DIFF
--- a/lib/state/app.js
+++ b/lib/state/app.js
@@ -134,17 +134,25 @@ App.prototype._frontendPod = function () {
       },
       namespace: this.id
     },
-    spec: {
-      containers: [
-        {
+      spec: {
+        volumes:[{
+            'name': 'no-api-access-please',
+            'emptyDir': {}
+          }],
+        containers: [{
           name: 'frontend-server',
           image: this.imageSource,
           ports: [{ 
             containerPort: this.port,
             protocol: 'TCP'
-          }],           
+          }],
           command: this.command,
-          imagePullPolicy: this.pullPolicy
+            imagePullPolicy: this.pullPolicy,
+            volumeMounts: [{
+                'name': 'no-api-access-please',
+                'mountPath': '/var/run/secrets/kubernetes.io/serviceaccount',
+                'readOnly': true
+            }]
         }
       ],
       dnsPolicy: 'Default',


### PR DESCRIPTION
This makes it a lot more secure. Otherwise, every pod has root access on the k8s cluster.